### PR TITLE
Support broadcast-only alarms

### DIFF
--- a/.idea/appInsightsSettings.xml
+++ b/.idea/appInsightsSettings.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="AppInsightsSettings">
+    <option name="tabSettings">
+      <map>
+        <entry key="Firebase Crashlytics">
+          <value>
+            <InsightsFilterSettings>
+              <option name="connection">
+                <ConnectionSetting>
+                  <option name="appId" value="de.coldtea.smplr.alarm" />
+                  <option name="mobileSdkAppId" value="1:762932834075:android:10da94985692474d43edbe" />
+                  <option name="projectId" value="smplralarm" />
+                  <option name="projectNumber" value="762932834075" />
+                </ConnectionSetting>
+              </option>
+              <option name="signal" value="SIGNAL_UNSPECIFIED" />
+              <option name="timeIntervalDays" value="THIRTY_DAYS" />
+              <option name="visibilityType" value="ALL" />
+            </InsightsFilterSettings>
+          </value>
+        </entry>
+      </map>
+    </option>
+  </component>
+</project>

--- a/.idea/deploymentTargetSelector.xml
+++ b/.idea/deploymentTargetSelector.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="deploymentTargetSelector">
+    <selectionStates>
+      <SelectionState runConfigName="app">
+        <option name="selectionMode" value="DROPDOWN" />
+        <DropdownSelection timestamp="2025-08-03T03:24:48.285398200Z">
+          <Target type="DEFAULT_BOOT">
+            <handle>
+              <DeviceId pluginId="LocalEmulator" identifier="path=C:\Android\.android\avd\Pixel_6_Pro_API_32.avd" />
+            </handle>
+          </Target>
+        </DropdownSelection>
+        <DialogSelection />
+      </SelectionState>
+    </selectionStates>
+  </component>
+</project>

--- a/.idea/kotlinc.xml
+++ b/.idea/kotlinc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="KotlinJpsPluginSettings">
+    <option name="version" value="1.7.22" />
+  </component>
+</project>

--- a/.idea/migrations.xml
+++ b/.idea/migrations.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectMigrations">
+    <option name="MigrateToGradleLocalJavaHome">
+      <set>
+        <option value="$PROJECT_DIR$" />
+      </set>
+    </option>
+  </component>
+</project>

--- a/.idea/runConfigurations.xml
+++ b/.idea/runConfigurations.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="RunConfigurationProducerService">
+    <option name="ignoredProducers">
+      <set>
+        <option value="com.intellij.execution.junit.AbstractAllInDirectoryConfigurationProducer" />
+        <option value="com.intellij.execution.junit.AllInPackageConfigurationProducer" />
+        <option value="com.intellij.execution.junit.TestInClassConfigurationProducer" />
+        <option value="com.intellij.execution.junit.UniqueIdConfigurationProducer" />
+      </set>
+    </option>
+  </component>
+</project>

--- a/README.md
+++ b/README.md
@@ -123,8 +123,8 @@ All that SmplrAlarm requires to set an alarm is an integer reperesenting the hou
 
 ````kotlin
 smplrAlarmSet(applicationContext) {
-	hour { hour }
-	min { minute }
+        hour { hour }
+        min { minute }
 }
 ````
 
@@ -143,9 +143,25 @@ smplrAlarmSet(applicationContext) {
 		monday()
 		friday()
 		sunday()
-	}
+        }
 }
 ````
+
+### Alarm without notification
+
+If you only need to react to an alarm in your own `BroadcastReceiver` without displaying any notification, simply omit the `notification` and `notificationChannel` blocks and supply an `alarmReceivedIntent`:
+
+````kotlin
+val alarmReceivedIntent = Intent(applicationContext, AlarmBroadcastReceiver::class.java)
+
+smplrAlarmSet(applicationContext) {
+    hour { hour }
+    min { minute }
+    alarmReceivedIntent { alarmReceivedIntent }
+}
+````
+
+This will trigger your `AlarmBroadcastReceiver` when the alarm goes off without showing any notification.
 
 ### Adding a notification and Notification channel
 

--- a/smplralarm/src/main/AndroidManifest.xml
+++ b/smplralarm/src/main/AndroidManifest.xml
@@ -20,6 +20,7 @@
             <intent-filter>
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
                 <action android:name="android.intent.action.QUICKBOOT_POWERON" />
+                <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
             </intent-filter>
         </receiver>
 

--- a/smplralarm/src/main/java/de/coldtea/smplr/smplralarm/receivers/AlarmReceiver.kt
+++ b/smplralarm/src/main/java/de/coldtea/smplr/smplralarm/receivers/AlarmReceiver.kt
@@ -3,6 +3,7 @@ package de.coldtea.smplr.smplralarm.receivers
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
+import de.coldtea.smplr.smplralarm.apis.SmplrAlarmAPI
 import de.coldtea.smplr.smplralarm.extensions.showNotification
 import de.coldtea.smplr.smplralarm.repository.AlarmNotificationRepository
 import de.coldtea.smplr.smplralarm.services.AlarmService
@@ -43,16 +44,22 @@ internal class AlarmReceiver : BroadcastReceiver() {
 
                         val alarmNotification = it.getAlarmNotification(requestId)
 
-                        alarmNotification.notificationChannelItem?.let { channel ->
-                            alarmNotification.notificationItem?.let { notification ->
-                                context.showNotification(
-                                    requestId = requestId,
-                                    notificationChannelItem = channel,
-                                    notificationItem = notification,
-                                    contentIntent = alarmNotification.contentIntent,
-                                    alarmReceivedIntent = alarmNotification.alarmReceivedIntent,
-                                    fullScreenIntent = alarmNotification.fullScreenIntent
-                                )
+                        val channel = alarmNotification.notificationChannelItem
+                        val notification = alarmNotification.notificationItem
+
+                        if (channel != null && notification != null) {
+                            context.showNotification(
+                                requestId = requestId,
+                                notificationChannelItem = channel,
+                                notificationItem = notification,
+                                contentIntent = alarmNotification.contentIntent,
+                                alarmReceivedIntent = alarmNotification.alarmReceivedIntent,
+                                fullScreenIntent = alarmNotification.fullScreenIntent
+                            )
+                        } else {
+                            alarmNotification.alarmReceivedIntent?.let { alarmIntent ->
+                                alarmIntent.putExtra(SmplrAlarmAPI.SMPLR_ALARM_REQUEST_ID, requestId)
+                                context.sendBroadcast(alarmIntent)
                             } ?: Timber.e("notification not found")
                         }
 

--- a/smplralarm/src/main/java/de/coldtea/smplr/smplralarm/receivers/RebootReceiver.kt
+++ b/smplralarm/src/main/java/de/coldtea/smplr/smplralarm/receivers/RebootReceiver.kt
@@ -20,7 +20,8 @@ internal class RebootReceiver : BroadcastReceiver() {
         Timber.i("onRecieve --> ${intent.action}")
         when (intent.action) {
             Intent.ACTION_BOOT_COMPLETED,
-            Intent.ACTION_LOCKED_BOOT_COMPLETED -> onBootComplete(context)
+            Intent.ACTION_LOCKED_BOOT_COMPLETED,
+            Intent.ACTION_MY_PACKAGE_REPLACED -> onBootComplete(context)
             else -> Timber.w("onRecieve --> Recieved illegal broadcast!")
         }
     }

--- a/smplralarm/src/main/java/de/coldtea/smplr/smplralarm/repository/AlarmNotificationRepository.kt
+++ b/smplralarm/src/main/java/de/coldtea/smplr/smplralarm/repository/AlarmNotificationRepository.kt
@@ -84,6 +84,7 @@ internal class AlarmNotificationRepository(
         }
 
             alarmNotificationDatabase.daoAlarmNotification.insert(alarmNotification.extractAlarmNotificationEntity())
+        alarmNotification.notificationItem?.let {
             alarmNotificationDatabase.daoNotificationChannel.insert(
                 alarmNotification.extractNotificationChannelEntity(
                     alarmNotification.alarmNotificationId
@@ -94,6 +95,9 @@ internal class AlarmNotificationRepository(
                     alarmNotification.alarmNotificationId
                 )
             )
+        }
+
+
 
 
     }


### PR DESCRIPTION
## Summary
- allow alarms to trigger only a broadcast receiver when no notification is supplied
- document broadcast-only alarm usage

## Testing
- `./gradlew test` *(fails: NoSuchAlgorithmException: Error constructing implementation)*

------
https://chatgpt.com/codex/tasks/task_e_688ebeec5ea88327868baf6ff443765e