### PR TITLE
Handle app update broadcast to restore alarms

### DIFF
--- a/smplralarm/src/main/AndroidManifest.xml
+++ b/smplralarm/src/main/AndroidManifest.xml
@@ -20,6 +20,7 @@
             <intent-filter>
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
                 <action android:name="android.intent.action.QUICKBOOT_POWERON" />
+                <action android:name="android.intent.action.MY_PACKAGE_REPLACED" />
             </intent-filter>
         </receiver>
 

--- a/smplralarm/src/main/java/de/coldtea/smplr/smplralarm/receivers/RebootReceiver.kt
+++ b/smplralarm/src/main/java/de/coldtea/smplr/smplralarm/receivers/RebootReceiver.kt
@@ -20,7 +20,8 @@ internal class RebootReceiver : BroadcastReceiver() {
         Timber.i("onRecieve --> ${intent.action}")
         when (intent.action) {
             Intent.ACTION_BOOT_COMPLETED,
-            Intent.ACTION_LOCKED_BOOT_COMPLETED -> onBootComplete(context)
+            Intent.ACTION_LOCKED_BOOT_COMPLETED,
+            Intent.ACTION_MY_PACKAGE_REPLACED -> onBootComplete(context)
             else -> Timber.w("onRecieve --> Recieved illegal broadcast!")
         }
     }


### PR DESCRIPTION
## Summary
- Reschedule alarms after the app is updated by reacting to `MY_PACKAGE_REPLACED`

## Testing
- `./gradlew test` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_e_6898025bae488327894c51defe1270c9